### PR TITLE
refactor(module): rename registerSync and registerAsync to forRoot and forRootAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ npm install --save murlock redis reflect-metadata
 
 MurLock is primarily used through the `@MurLock()` decorator.
 
-First, you need to import and register the `MurLockModule` in your module:
+First, you need to import the `MurLockModule` and set it up in your module using `forRoot`. This method is used for global configuration that can be reused across different parts of your application.
 
 ```typescript
 import { MurLockModule } from 'murlock';
 
 @Module({
   imports: [
-    MurLockModule.registerSync({
+    MurLockModule.forRoot({
       redisOptions: { host: 'localhost', port: 6379 },
       wait: 1000,
       maxAttempts: 3,
@@ -55,7 +55,7 @@ export class AppService {
 }
 ```
 
-By default, if there is single wrapped parameter, the property of parameter can be called direcly as it shown
+By default, if there is single wrapped parameter, the property of parameter can be called directly as it shown
 
 ```typescript
 import { MurLock } from 'murlock';
@@ -96,7 +96,7 @@ import { MurLockModule } from 'murlock';
 
 @Module({
   imports: [
-    MurLockModule.registerAsync({
+    MurLockModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => ({
         redisOptions: configService.get('REDIS_OPTIONS'),

--- a/lib/murlock.module.ts
+++ b/lib/murlock.module.ts
@@ -17,7 +17,7 @@ import { ClsModule } from 'nestjs-cls';
   exports: [MurLockService],
 })
 export class MurLockModule {
-  static registerSync(options: MurLockModuleOptions): DynamicModule {
+  static forRoot(options: MurLockModuleOptions): DynamicModule {
     return {
       module: MurLockModule,
       providers: [
@@ -39,7 +39,7 @@ export class MurLockModule {
     };
   }
 
-  static registerAsync(options: MurLockModuleAsyncOptions): DynamicModule {
+  static forRootAsync(options: MurLockModuleAsyncOptions): DynamicModule {
     return {
       module: MurLockModule,
       imports: options.imports || [],


### PR DESCRIPTION
BREAKING CHANGE:
Renamed registerSync to forRoot and registerAsync to forRootAsync. This aligns with standard module configuration terminology in NestJS. Users must update their code where registerSync and registerAsync were used to the new method names. This major change affects all implementations of the MurLockModule.