### PR TITLE
fix(cls): remove ClsModule and bump version 3.1.0

### DIFF
--- a/lib/lua/lock.lua
+++ b/lib/lua/lock.lua
@@ -2,7 +2,7 @@ local key = KEYS[1]
 local clientId = ARGV[1]
 local releaseTime = ARGV[2]
 
-if redis.call("get",key) == clientId or redis.call("set", key, clientId, "NX", "PX", releaseTime) then
+if redis.call("get", key) == clientId or redis.call("set", key, clientId, "NX", "PX", releaseTime) then
   return 1
 else
   return 0

--- a/lib/murlock.module.ts
+++ b/lib/murlock.module.ts
@@ -3,16 +3,10 @@ import { MurLockService } from './murlock.service';
 import 'reflect-metadata';
 import { MurLockModuleAsyncOptions, MurLockModuleOptions } from './interfaces';
 import { MURLOCK_SERVICE_METADATA_KEY } from './constants';
-import { ClsModule } from 'nestjs-cls';
 
 @Global()
 @Module({
-  imports: [
-    ClsModule.forRoot({
-      global: true,
-      interceptor: { mount: true },
-    }),
-  ],
+  imports: [],
   providers: [MurLockService],
   exports: [MurLockService],
 })

--- a/lib/murlock.service.ts
+++ b/lib/murlock.service.ts
@@ -3,7 +3,6 @@ import { createClient, RedisClientType } from 'redis';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { MurLockModuleOptions } from './interfaces';
-import { ClsService } from 'nestjs-cls';
 import { MurLockRedisException, MurLockException } from './exceptions';
 
 /**
@@ -15,10 +14,10 @@ export class MurLockService implements OnModuleInit, OnApplicationShutdown {
   private redisClient: RedisClientType;
   private readonly lockScript = readFileSync(join(__dirname, './lua/lock.lua')).toString();
   private readonly unlockScript = readFileSync(join(__dirname, './lua/unlock.lua')).toString();
+  private clientId: string | undefined;
 
   constructor(
     @Inject('MURLOCK_OPTIONS') protected readonly options: MurLockModuleOptions,
-    private readonly clsService: ClsService,
   ) { }
 
   async onModuleInit() {
@@ -50,12 +49,11 @@ export class MurLockService implements OnModuleInit, OnApplicationShutdown {
   }
 
   private getClientId(): string {
-    let clientId = this.clsService.get('clientId');
-    if (!clientId) {
-      clientId = this.generateUuid();
-      this.clsService.set('clientId', clientId);
+    if (this.clientId) {
+      return this.clientId;
     }
-    return clientId;
+
+    return this.clientId = this.generateUuid();
   }
 
   private sleep(ms: number): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@nestjs/common": "^10.0.5",
         "@nestjs/core": "^10.0.5",
-        "nestjs-cls": "^3.5.0",
         "redis": "^4.6.10",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1"
@@ -3457,18 +3456,6 @@
       "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
       "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
       "dev": true
-    },
-    "node_modules/nestjs-cls": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/nestjs-cls/-/nestjs-cls-3.5.0.tgz",
-      "integrity": "sha512-C7JX4Q8scpmCl4fZsNjx2JS50rL1fhdx2mckkZo300dUviVLiYMmy5Q0bXnrwW2cquk78mi9Vd3WlGuYCrExDQ==",
-      "engines": {
-        "node": ">=12.17.0"
-      },
-      "peerDependencies": {
-        "@nestjs/common": "> 7.0.0 < 11",
-        "@nestjs/core": "> 7.0.0 < 11"
-      }
     },
     "node_modules/node-emoji": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murlock",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A distributed locking solution for NestJS, providing a decorator for critical sections with Redis-based synchronization.",
   "author": "https://github.com/felanios",
   "homepage": "https://github.com/felanios/murlock#readme",
@@ -16,7 +16,6 @@
   "dependencies": {
     "@nestjs/common": "^10.0.5",
     "@nestjs/core": "^10.0.5",
-    "nestjs-cls": "^3.5.0",
     "redis": "^4.6.10",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"


### PR DESCRIPTION
Pull request for removing the ClsModule.
The client id is generated and kept inside **MurLockService**.