### PR TITLE
Fix type safety and undefined parameter handling in MurLock

### DIFF
--- a/lib/decorators/murlock.decorator.ts
+++ b/lib/decorators/murlock.decorator.ts
@@ -52,7 +52,10 @@ export function MurLock(
   ) {
     wait = waitOrKeyParam;
   } else {
-    keyParams = [waitOrKeyParam, ...keyParams];
+    keyParams = [
+      ...(waitOrKeyParam === undefined ? [] : [waitOrKeyParam]),
+      ...keyParams,
+    ];
   }
 
   const injectMurlockService = Inject(MurLockService);

--- a/lib/murlock.service.ts
+++ b/lib/murlock.service.ts
@@ -192,13 +192,13 @@ export class MurLockService implements OnModuleInit, OnApplicationShutdown {
     lockKey: string,
     releaseTime: number,
     fn: () => Promise<R>
-  );
+  ): Promise<R>;
   async runWithLock<R>(
     lockKey: string,
     releaseTime: number,
     wait: number | ((retries: number) => number),
     fn: () => Promise<R>
-  );
+  ): Promise<R>;
   async runWithLock<R>(
     lockKey: string,
     releaseTime: number,


### PR DESCRIPTION
### Problem
This PR addresses two critical issues in the MurLock library:

1. **Type Safety Issue**: The `runWithLock` method overloads were returning `any` type instead of the proper `Promise<R>` type, which breaks type safety and IDE autocomplete functionality.

2. **Runtime Error with Undefined Parameters**: When the MurLock decorator is used without key parameters, it incorrectly handles undefined values, leading to a `TypeError: Cannot read properties of undefined (reading 'split')` when trying to process `keyParams`.

### Solution

#### 1. Fixed Return Type Annotations
```typescript
// Before
runWithLock<R>(lockKey: string, releaseTime: number, fn: () => Promise<R>): any;
runWithLock<R>(lockKey: string, releaseTime: number, wait: number | ((retries: number) => number), fn: () => Promise<R>): any;

// After  
runWithLock<R>(lockKey: string, releaseTime: number, fn: () => Promise<R>): Promise<R>;
runWithLock<R>(lockKey: string, releaseTime: number, wait: number | ((retries: number) => number), fn: () => Promise<R>): Promise<R>;
```

#### 2. Added Proper Undefined Handling
```typescript
// Before
keyParams = [waitOrKeyParam, ...keyParams];

// After
keyParams = [
  ...(waitOrKeyParam === undefined ? [] : [waitOrKeyParam]),
  ...keyParams,
];
```

### Changes Made
- Fixed `runWithLock` overload return types from `any` to `Promise<R>`
- Added undefined check before spreading `waitOrKeyParam` into `keyParams` array
- Prevents runtime TypeError when no key parameters are provided to MurLock decorator

### Files Changed
- `lib/decorators/murlock.decorator.ts` - Fixed undefined parameter handling
- `lib/murlock.service.ts` - Corrected return type annotations
