### PR TITLE
feat: enhance MurLock decorator to preserve metadata

### DIFF
--- a/test/unit/decorator.spec.ts
+++ b/test/unit/decorator.spec.ts
@@ -1,4 +1,6 @@
 import { MurLock } from '../../lib/decorators/murlock.decorator';
+import 'reflect-metadata';
+import { SetMetadata } from '@nestjs/common';
 
 describe('MurLock Decorator', () => {
   it('should parse decorator parameters correctly (dry test)', () => {
@@ -7,5 +9,29 @@ describe('MurLock Decorator', () => {
       async criticalSection() {}
     }
     expect(true).toBe(true);
+  });
+
+  it('should preserve metadata when MurLock is below other decorators', () => {
+    const KEY = 'custom:meta';
+    class TestClass {
+      @SetMetadata(KEY, 'value-a')
+      @MurLock(1000, 'userId')
+      methodA() {}
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(TestClass.prototype, 'methodA');
+    const value = Reflect.getMetadata(KEY, descriptor?.value);
+    expect(value).toBe('value-a');
+  });
+
+  it('should preserve metadata when MurLock is above other decorators', () => {
+    const KEY = 'custom:meta';
+    class TestClass {
+      @MurLock(1000, 'userId')
+      @SetMetadata(KEY, 'value-b')
+      methodB() {}
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(TestClass.prototype, 'methodB');
+    const value = Reflect.getMetadata(KEY, descriptor?.value);
+    expect(value).toBe('value-b');
   });
 });


### PR DESCRIPTION
- Added functionality to retain metadata when the MurLock decorator is applied above or below other decorators.
- Updated the decorator implementation to use a wrapped function for better metadata handling.
- Included unit tests to verify metadata preservation in various decorator order scenarios.