### PR TITLE
[Addresses #67] fix(decorator): resolve parameter name extraction with decorator

### DIFF
--- a/test/unit/decorator.spec.ts
+++ b/test/unit/decorator.spec.ts
@@ -1,6 +1,10 @@
-import { MurLock } from '../../lib/decorators/murlock.decorator';
-import 'reflect-metadata';
 import { SetMetadata } from '@nestjs/common';
+import 'reflect-metadata';
+import {
+  MurLock,
+  PARAM_NAMES_KEY,
+  SetParamNames,
+} from '../../lib/decorators/murlock.decorator';
 
 describe('MurLock Decorator', () => {
   it('should parse decorator parameters correctly (dry test)', () => {
@@ -18,7 +22,10 @@ describe('MurLock Decorator', () => {
       @MurLock(1000, 'userId')
       methodA() {}
     }
-    const descriptor = Object.getOwnPropertyDescriptor(TestClass.prototype, 'methodA');
+    const descriptor = Object.getOwnPropertyDescriptor(
+      TestClass.prototype,
+      'methodA'
+    );
     const value = Reflect.getMetadata(KEY, descriptor?.value);
     expect(value).toBe('value-a');
   });
@@ -30,8 +37,153 @@ describe('MurLock Decorator', () => {
       @SetMetadata(KEY, 'value-b')
       methodB() {}
     }
-    const descriptor = Object.getOwnPropertyDescriptor(TestClass.prototype, 'methodB');
+    const descriptor = Object.getOwnPropertyDescriptor(
+      TestClass.prototype,
+      'methodB'
+    );
     const value = Reflect.getMetadata(KEY, descriptor?.value);
     expect(value).toBe('value-b');
+  });
+
+  describe('Issue #67: Parameter name extraction with decorator composition', () => {
+    // Simulate a decorator that wraps methods (like @Transactional)
+    // This wraps the method with a function that uses ...args, making parameter names unextractable
+    function WrappingDecorator() {
+      return function (
+        target: any,
+        propertyKey: string,
+        descriptor: PropertyDescriptor
+      ) {
+        const originalMethod = descriptor.value;
+        descriptor.value = async function (...args: any[]) {
+          return originalMethod.apply(this, args);
+        };
+        return descriptor;
+      };
+    }
+
+    it('should fail when SetParamNames is used above MurLock (wrong order)', () => {
+      // This test demonstrates the WRONG order - SetParamNames above MurLock
+      // Decorator execution order (bottom-up):
+      // 1. WrappingDecorator (wraps method)
+      // 2. MurLock (executes BEFORE SetParamNames, so metadata is NOT available)
+      // 3. SetParamNames (sets metadata AFTER MurLock has already executed)
+      //
+      // In this case, @MurLock will fail to find parameter names because
+      // metadata hasn't been set yet when it executes.
+      // This is why SetParamNames should be placed BELOW MurLock.
+      class TestClass {
+        // @ts-ignore - Decorator type checking issue in test environment
+        @SetParamNames('userData', 'options')
+        // @ts-ignore - Decorator type checking issue in test environment
+        @MurLock(1000, 'userData.id')
+        // @ts-ignore - Decorator type checking issue in test environment
+        @WrappingDecorator()
+        async process(
+          userData: { id: string },
+          options: string[] = []
+        ): Promise<any> {
+          return { success: true };
+        }
+      }
+
+      // Even though metadata is eventually stored, @MurLock executed before it was set
+      // So @MurLock would have failed to find 'userData' parameter
+      // This test verifies that metadata is stored, but the actual usage would fail
+      const paramNames = Reflect.getMetadata(
+        PARAM_NAMES_KEY,
+        TestClass.prototype,
+        'process'
+      );
+      expect(paramNames).toEqual(['userData', 'options']);
+      // Note: In practice, this order would cause @MurLock to throw an error
+      // because it can't find 'userData' when it executes
+    });
+
+    it('should extract parameter names when SetParamNames is used below MurLock', () => {
+      // This is the CORRECT order for SetParamNames to work with MurLock
+      // Decorator execution order (bottom-up):
+      // 1. WrappingDecorator (wraps method)
+      // 2. SetParamNames (sets metadata BEFORE MurLock executes)
+      // 3. MurLock (reads metadata set by SetParamNames)
+      class TestClass {
+        // @ts-ignore - Decorator type checking issue in test environment
+        @MurLock(1000, 'userData.id')
+        // @ts-ignore - Decorator type checking issue in test environment
+        @SetParamNames('userData', 'options')
+        // @ts-ignore - Decorator type checking issue in test environment
+        @WrappingDecorator()
+        async process(
+          userData: { id: string },
+          options: string[] = []
+        ): Promise<any> {
+          return { success: true };
+        }
+      }
+
+      // Verify that parameter names are stored in metadata
+      const paramNames = Reflect.getMetadata(
+        PARAM_NAMES_KEY,
+        TestClass.prototype,
+        'process'
+      );
+      expect(paramNames).toEqual(['userData', 'options']);
+    });
+
+    it('should auto-save parameter names when method is not wrapped', () => {
+      // When no wrapping decorator is present, MurLock should extract and save parameter names
+      class TestClass {
+        @MurLock(1000, 'userData.id')
+        async process(
+          userData: { id: string },
+          options: string[] = []
+        ): Promise<any> {
+          return { success: true };
+        }
+      }
+
+      // Verify that parameter names are automatically stored in metadata
+      const paramNames = Reflect.getMetadata(
+        PARAM_NAMES_KEY,
+        TestClass.prototype,
+        'process'
+      );
+      expect(paramNames).toEqual(['userData', 'options']);
+    });
+
+    it('should work with name-based keys when SetParamNames is used in correct order', () => {
+      // CORRECT order: SetParamNames below MurLock
+      // Decorator execution order (bottom-up):
+      // 1. WrappingDecorator (wraps method)
+      // 2. SetParamNames (sets metadata BEFORE MurLock executes)
+      // 3. MurLock (reads metadata set by SetParamNames)
+      class TestClass {
+        // @ts-ignore - Decorator type checking issue in test environment
+        @MurLock(1000, 'userData.id')
+        // @ts-ignore - Decorator type checking issue in test environment
+        @SetParamNames('userData', 'options') // Correct: below @MurLock
+        // @ts-ignore - Decorator type checking issue in test environment
+        @WrappingDecorator()
+        async process(
+          userData: { id: string },
+          options: string[] = []
+        ): Promise<any> {
+          return { success: true };
+        }
+      }
+
+      // Verify that parameter names are stored in metadata
+      const paramNames = Reflect.getMetadata(
+        PARAM_NAMES_KEY,
+        TestClass.prototype,
+        'process'
+      );
+      expect(paramNames).toEqual(['userData', 'options']);
+
+      // Verify that the decorator was applied correctly
+      const instance = new TestClass();
+      expect(instance.process).toBeDefined();
+      expect(typeof instance.process).toBe('function');
+    });
   });
 });


### PR DESCRIPTION
# Fix: Resolve parameter name extraction issue with decorator composition (#67)

## Problem

Issue #67 reported that when `@MurLock` is used with other decorators like `@Transactional`, parameter name extraction fails because:
- TypeScript decorators execute bottom-up
- When `@Transactional` wraps the method before `@MurLock` executes, `getParameterNames()` cannot extract parameter names from wrapped functions
- This forces users to use index-based keys (`'0.id'`) instead of name-based keys (`'userData.id'`)

PR #68 addressed metadata preservation but didn't solve the core parameter name extraction problem.

## Solution

This PR implements a comprehensive solution:

### 1. Metadata-based Parameter Name Storage/Restoration
- Added `PARAM_NAMES_KEY` Symbol (exported for external use)
- Implemented `getParameterNamesWithFallback()` that:
  - First attempts direct parameter name extraction
  - Falls back to reading from metadata when extraction fails
  - Automatically stores extracted parameter names in metadata for future decorators

### 2. `SetParamNames` Helper Decorator
- New decorator allowing users to explicitly set parameter names
- Works seamlessly with `@MurLock` when decorator composition is needed
- Properly documented with execution order notes

### 3. Improved Parameter Parsing
- Enhanced `getParameterNames()` to handle:
  - Default parameter values (e.g., `options: string[] = []`)
  - Nested structures (parentheses, brackets, braces)
  - String literals containing commas

## Changes

- **New exports**: `PARAM_NAMES_KEY`, `SetParamNames`
- **New function**: `getParameterNamesWithFallback()` with metadata fallback
- **Enhanced**: `getParameterNames()` with better parsing logic
- **Updated**: `@MurLock` decorator to use fallback mechanism and auto-save parameter names
- **Added**: Comprehensive unit tests for decorator composition scenarios
- **Updated**: README with decorator composition documentation

## Usage

```typescript
import { MurLock, SetParamNames } from 'murlock';

class MyService {
  @MurLock(5000, 'userData.id')
  @SetParamNames('userData', 'options')  // Must be below @MurLock
  @Transactional()
  async process(userData: { id: string }, options: string[] = []): Promise<any> {
    // Now works correctly with name-based keys!
  }
}
```

**Note**: Due to TypeScript's bottom-up decorator execution order, `@SetParamNames` must be placed below `@MurLock` in the code.

## Testing

- ✅ Unit tests for `SetParamNames` in various decorator orders
- ✅ Tests for automatic parameter name extraction and storage
- ✅ Tests for default parameter value handling
- ✅ All existing tests pass

## Breaking Changes

None. This is a backward-compatible enhancement.

## Related Issues

Fixes #67

