### PR TITLE
[Addresses #67] feat(decorator): add object format for SetParamNames with partial parameter support

### DIFF
--- a/lib/decorators/murlock.decorator.ts
+++ b/lib/decorators/murlock.decorator.ts
@@ -4,10 +4,21 @@ import { MurLockException } from '../exceptions';
 import { MurLockService } from '../murlock.service';
 
 /**
- * Metadata key for storing parameter names
+ * Metadata key for storing parameter names (legacy array format)
  * This allows decorator composition by preserving parameter names even when methods are wrapped
  */
 export const PARAM_NAMES_KEY = Symbol('murlock:param-names');
+
+/**
+ * Metadata key for storing parameter name to index mapping (new object format)
+ * This provides O(1) lookup and allows partial parameter specification
+ */
+export const PARAM_INDEX_MAP_KEY = Symbol('murlock:param-index-map');
+
+/**
+ * Type for parameter name to index mapping
+ */
+export type ParamIndexMap = Record<string, number>;
 
 /**
  * Helper decorator to explicitly set parameter names for a method
@@ -18,11 +29,22 @@ export const PARAM_NAMES_KEY = Symbol('murlock:param-names');
  *
  * @example
  * ```typescript
+ * // Option 1: Object format (recommended) - specify only what you need, order doesn't matter
  * class MyService {
  *   @MurLock(5000, 'userData.id')
- *   @SetParamNames('userData', 'options')  // Must be below @MurLock
+ *   @SetParamNames({ userData: 0, context: 2 })  // Only specify needed params with their indices
  *   @Transactional()
- *   async process(userData: { id: string }, options: string[] = []): Promise<any> {
+ *   async process(userData: { id: string }, options: string[], context: { tenant: string }): Promise<any> {
+ *     // ...
+ *   }
+ * }
+ *
+ * // Option 2: Array format (legacy) - must specify ALL params in order
+ * class MyService {
+ *   @MurLock(5000, 'userData.id')
+ *   @SetParamNames('userData', 'options', 'context')  // Must be below @MurLock
+ *   @Transactional()
+ *   async process(userData: { id: string }, options: string[], context: { tenant: string }): Promise<any> {
  *     // ...
  *   }
  * }
@@ -33,16 +55,32 @@ export const PARAM_NAMES_KEY = Symbol('murlock:param-names');
  * 2. @SetParamNames stores parameter names in metadata
  * 3. @MurLock reads parameter names from metadata
  *
- * @param {...string} paramNames The parameter names in order
+ * @param {ParamIndexMap | string} mappingOrFirstParam - Object mapping param names to indices, or first param name
+ * @param {...string} restParamNames - Remaining parameter names (only for array format)
  * @returns A decorator function
  */
-export function SetParamNames(...paramNames: string[]) {
+export function SetParamNames(
+  mappingOrFirstParam: ParamIndexMap | string,
+  ...restParamNames: string[]
+) {
   return function (
     target: any,
     propertyKey: string,
     descriptor: PropertyDescriptor
   ): PropertyDescriptor {
-    Reflect.defineMetadata(PARAM_NAMES_KEY, paramNames, target, propertyKey);
+    if (typeof mappingOrFirstParam === 'object') {
+      // Object format: { paramName: index }
+      Reflect.defineMetadata(
+        PARAM_INDEX_MAP_KEY,
+        mappingOrFirstParam,
+        target,
+        propertyKey
+      );
+    } else {
+      // Array format: legacy support
+      const paramNames = [mappingOrFirstParam, ...restParamNames];
+      Reflect.defineMetadata(PARAM_NAMES_KEY, paramNames, target, propertyKey);
+    }
     return descriptor;
   };
 }
@@ -199,6 +237,13 @@ export function MurLock(
       propertyKey
     );
 
+    // Check for object-format param index map (new format, O(1) lookup)
+    const paramIndexMap = Reflect.getMetadata(
+      PARAM_INDEX_MAP_KEY,
+      target,
+      propertyKey
+    ) as ParamIndexMap | undefined;
+
     // If we successfully extracted parameter names and they're not already in metadata,
     // store them for future decorators that might wrap this method
     if (
@@ -220,8 +265,27 @@ export function MurLock(
       }
     }
 
+    /**
+     * Resolve parameter index from source name
+     * Priority: 1) numeric index, 2) object map (O(1)), 3) array indexOf (O(n))
+     */
+    function resolveParameterIndex(source: string): number {
+      // 1. Direct numeric index (e.g., '0', '1', '2')
+      if (isNumber(source)) {
+        return Number(source);
+      }
+
+      // 2. Object-format map lookup (O(1)) - new recommended format
+      if (paramIndexMap && source in paramIndexMap) {
+        return paramIndexMap[source];
+      }
+
+      // 3. Array-based lookup (O(n)) - legacy format
+      return methodParameterNames.indexOf(source);
+    }
+
     function constructLockKey(args: any[], lockKeyPrefix = 'default'): string {
-      let lockKeyElements = [];
+      const lockKeyElements: string[] = [];
       if (lockKeyPrefix != 'custom') {
         lockKeyElements.push(target.constructor.name);
         lockKeyElements.push(propertyKey);
@@ -230,9 +294,8 @@ export function MurLock(
       lockKeyElements.push(
         ...keyParams.map((keyParam) => {
           const [source, path] = keyParam.split('.');
-          const parameterIndex = isNumber(source)
-            ? Number(source)
-            : methodParameterNames.indexOf(source);
+          const parameterIndex = resolveParameterIndex(source);
+
           if (parameterIndex >= 0) {
             const parameterValue = findParameterValue({
               args,


### PR DESCRIPTION
## Background

This is a follow-up improvement to PR #72, which addressed issue #67 for parameter name extraction with decorator composition.

After merging #72, I discovered that the array format of `SetParamNames` had a limitation: it required specifying ALL parameters in order, even if only one parameter was needed for the lock key. This was because the implementation used `indexOf` to find parameter indices.

I apologize for not implementing a complete solution from the beginning. This PR adds a more flexible and performant approach.

## Changes

### New Object Format for SetParamNames

Added support for an object format that allows partial parameter specification with explicit index mapping:

```typescript
// Before (array format) - must specify ALL params in order
@SetParamNames('userData', 'options', 'context')

// After (object format) - only specify what you need
@SetParamNames({ userData: 0, context: 2 })
```

### Implementation Details

- Added `PARAM_INDEX_MAP_KEY` Symbol for storing object-format mappings
- Added `ParamIndexMap` type (`Record<string, number>`) for type safety
- Implemented `resolveParameterIndex` function with priority:
  1. Numeric index (e.g., `'0'`, `'1'`)
  2. Object map lookup (O(1))
  3. Array indexOf (O(n)) - legacy fallback
- Full backward compatibility with existing array format

### Benefits

| Feature | Array Format | Object Format |
|---------|--------------|---------------|
| Partial specification | No (all params required) | Yes |
| Order dependent | Yes | No |
| Lookup performance | O(n) | O(1) |

## Usage Example

```typescript
import { MurLock, SetParamNames } from 'murlock';

class MyService {
  // Only need 'context' (index 2) for the lock key
  @MurLock(5000, 'context.tenantId')
  @SetParamNames({ context: 2 })
  @Transactional()
  async process(
    userData: { id: string },
    options: string[],
    context: { tenantId: string }
  ): Promise<any> {
    // Works correctly with partial parameter specification
  }
}
```

## Files Changed

- `lib/decorators/murlock.decorator.ts` - Core implementation
- `test/unit/decorator.spec.ts` - Unit tests for object format
- `README.md` - Documentation with examples

## Testing

- All existing tests pass
- Added new tests for object format functionality

## Breaking Changes

None. This is a backward-compatible enhancement.

## Related

- Addresses limitation discovered in #72
- Original issue: #67
