### PR TITLE
Fix @MurLock Decorator Causes Incorrect Rendering in NestJS Swagger CLI Plugin

### DIFF
--- a/lib/decorators/murlock.decorator.ts
+++ b/lib/decorators/murlock.decorator.ts
@@ -367,6 +367,14 @@ export function MurLock(
       (Reflect as any).defineMetadata(key, value, wrapped);
     }
 
+    // Preserve the function name so that NestJS Swagger's ParameterMetadataAccessor
+    // can correctly look up PARAMTYPES_METADATA and ROUTE_ARGS_METADATA
+    // using method.name as the property key.
+    Object.defineProperty(wrapped, 'name', {
+      value: propertyKey,
+      configurable: true,
+    });
+
     descriptor.value = wrapped;
 
     return descriptor;

--- a/test/unit/decorator.spec.ts
+++ b/test/unit/decorator.spec.ts
@@ -46,6 +46,18 @@ describe('MurLock Decorator', () => {
     expect(value).toBe('value-b');
   });
 
+  it('should preserve the method name on the wrapped function', () => {
+    class TestClass {
+      @MurLock(1000, 'id')
+      async myMethod(id: string) {}
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(
+      TestClass.prototype,
+      'myMethod'
+    );
+    expect(descriptor?.value.name).toBe('myMethod');
+  });
+
   describe('Issue #67: Parameter name extraction with decorator composition', () => {
     // Simulate a decorator that wraps methods (like @Transactional)
     // This wraps the method with a function that uses ...args, making parameter names unextractable


### PR DESCRIPTION
NestJS Swagger `ParameterMetadataAccessor` retrieves relevant information based on [method.name](https://github.com/nestjs/swagger/blob/master/lib/services/parameter-metadata-accessor.ts#L46).

Close #71 